### PR TITLE
Allow marking impl blocks unstable/stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Allow placing `instability` and `stability` on `impl` blocks
+
 ## [0.3.3](https://github.com/ratatui/instability/compare/instability-v0.3.2...instability-v0.3.3) - 2024-11-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Allow placing `instability` and `stability` on `impl` blocks
+- Allow placing `instability` and `stability` on `impl` blocks ([#15](https://github.com/ratatui/instability/pull/15))
 
 ## [0.3.3](https://github.com/ratatui/instability/compare/instability-v0.3.2...instability-v0.3.3) - 2024-11-12
 

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -140,6 +140,9 @@ pub trait StableTrait {
     // fn unstable_trait_method(&self);
 }
 
+#[instability::stable(since = "v1.0.0")]
+impl StableTrait for StableStruct {}
+
 /// An unstable trait
 ///
 /// This trait is unstable
@@ -159,6 +162,9 @@ pub trait UnstableTrait {
     // #[instability::unstable(feature = "trait-method")]
     // fn unstable_trait_method(&self);
 }
+
+#[instability::unstable(feature = "trait")]
+impl UnstableTrait for StableStruct {}
 
 /// A stable enum
 ///

--- a/src/item_like.rs
+++ b/src/item_like.rs
@@ -1,11 +1,13 @@
 use syn::Visibility;
 
-pub trait ItemLike {
+pub trait Stability {
     #[allow(unused)]
     fn attrs(&self) -> &[syn::Attribute];
 
     fn push_attr(&mut self, attr: syn::Attribute);
+}
 
+pub trait ItemLike: Stability {
     fn visibility(&self) -> &Visibility;
 
     fn set_visibility(&mut self, visibility: Visibility);
@@ -18,7 +20,7 @@ pub trait ItemLike {
 macro_rules! impl_has_visibility {
 ($($ty:ty),+ $(,)?) => {
     $(
-        impl ItemLike for $ty {
+        impl Stability for $ty {
             fn attrs(&self) -> &[syn::Attribute] {
                 &self.attrs
             }
@@ -26,7 +28,9 @@ macro_rules! impl_has_visibility {
             fn push_attr(&mut self, attr: syn::Attribute) {
                 self.attrs.push(attr);
             }
+        }
 
+        impl ItemLike for $ty {
             fn visibility(&self) -> &Visibility {
                 &self.vis
             }
@@ -50,7 +54,7 @@ impl_has_visibility!(
     syn::ItemUse,
 );
 
-impl ItemLike for syn::ItemStruct {
+impl Stability for syn::ItemStruct {
     fn attrs(&self) -> &[syn::Attribute] {
         &self.attrs
     }
@@ -58,7 +62,9 @@ impl ItemLike for syn::ItemStruct {
     fn push_attr(&mut self, attr: syn::Attribute) {
         self.attrs.push(attr);
     }
+}
 
+impl ItemLike for syn::ItemStruct {
     fn visibility(&self) -> &Visibility {
         &self.vis
     }
@@ -72,5 +78,15 @@ impl ItemLike for syn::ItemStruct {
             .for_each(|field| field.vis = visibility.clone());
 
         self.vis = visibility;
+    }
+}
+
+impl Stability for syn::ItemImpl {
+    fn attrs(&self) -> &[syn::Attribute] {
+        &self.attrs
+    }
+
+    fn push_attr(&mut self, attr: syn::Attribute) {
+        self.attrs.push(attr);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ mod unstable;
 /// - Changes the visibility of the item from `pub` to `pub(crate)` unless a certain crate feature
 ///   is enabled. This ensures that internal code within the crate can always use the item, but
 ///   downstream consumers cannot access it unless they opt-in to the unstable API.
+/// - Annotated `impl` blocks will instead be removed.
 /// - Changes the Visibility of certain child items of the annotated item (such as struct fields) to
 ///   match the item's visibility. Children that are not public will not be affected.
 /// - Appends an "Stability" section to the item's documentation that notes that the item is
@@ -102,6 +103,20 @@ mod unstable;
 /// #[cfg(not(feature = "unstable-risky-function"))]
 /// pub(crate) fn risky_function() {
 ///     unimplemented!()
+/// }
+/// ```
+///
+/// We can also apply the attribute to an `impl` block like so:
+///
+/// ```
+/// /// This structure is responsible for bar.
+/// pub struct Foo;
+///
+/// #[instability::unstable(feature = "unstable-dependency")]
+/// impl Default for Foo {
+///     fn default() -> Self {
+///         unimplemented!()
+///     }
 /// }
 /// ```
 #[proc_macro_attribute]

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -304,4 +304,17 @@ mod tests {
         };
         assert_eq!(tokens.to_string(), expected.to_string());
     }
+
+    #[test]
+    fn expand_impl_block() {
+        let item: syn::ItemImpl = parse_quote! {
+            impl Default for crate::foo::Foo {}
+        };
+        let tokens = StableAttribute::default().expand_impl(item);
+        let expected = quote! {
+            #[doc = #STABLE_DOC]
+            impl Default for crate::foo::Foo {}
+        };
+        assert_eq!(tokens.to_string(), expected.to_string());
+    }
 }

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -395,4 +395,19 @@ mod tests {
         };
         assert_eq!(tokens.to_string(), expected.to_string());
     }
+
+    #[test]
+    fn expand_impl_block() {
+        let item: syn::ItemImpl = parse_quote! {
+            impl Default for crate::foo::Foo {}
+        };
+        let tokens = UnstableAttribute::default().expand_impl(item);
+        let expected = quote! {
+            #[cfg(any(doc, feature = "unstable"))]
+            #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+            #[doc = #DEFAULT_DOC]
+            impl Default for crate::foo::Foo {}
+        };
+        assert_eq!(tokens.to_string(), expected.to_string());
+    }
 }


### PR DESCRIPTION
This PR results in the following additional ability, which is useful for documenting unstable implementations of dependencies.

![image](https://github.com/user-attachments/assets/b8862ba3-6d79-4e47-81e1-83cd38ab1a8c)