### PR TITLE
Add `document-unstable` default-feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
         run: cargo generate-lockfile
       - name: cargo test --locked
         run: cargo test --locked --all-features --all-targets
+      - name: cargo test --no-default-features
+        run: cargo test --locked --no-default-features --all-targets
       - name: cargo test --doc
         run: cargo test --locked --all-features --doc
   minimal-versions:
@@ -80,6 +82,8 @@ jobs:
         run: cargo +nightly update -Zdirect-minimal-versions
       - name: cargo test
         run: cargo test --locked --all-features --all-targets
+      - name: cargo test --no-default-features
+        run: cargo test --locked --no-default-features --all-targets
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
   os-check:
@@ -100,6 +104,8 @@ jobs:
         run: cargo generate-lockfile
       - name: cargo test
         run: cargo test --locked --all-features --all-targets
+      - name: cargo test --no-default-features
+        run: cargo test --locked --no-default-features --all-targets
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
   coverage:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,10 @@ syn = { version = "2.0.90", features = ["derive", "full"] }
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 
+[features]
+default = ["document-unstable"]
+
+document-unstable = []
+
 [lib]
 proc-macro = true


### PR DESCRIPTION
This adds a default feature to include the `cfg(doc)` - this makes it possible to opt-out and generate docs including just the public-API-surface (and helps in using e.g. cargo-semver-checks to check the public API surface)
